### PR TITLE
Version 3.3.3 - Bugfixes following the test

### DIFF
--- a/src/codycolor-server/gameRooms/gameRoomsUtils.js
+++ b/src/codycolor-server/gameRooms/gameRoomsUtils.js
@@ -385,7 +385,9 @@
         let lowerMatchTime = 0;
 
         for (let i = 0; i < gameRooms[gameRoomId].players.length; i++) {
-            if (i === 0 || gameRooms[gameRoomId].players[i].gameData.match.time < lowerMatchTime)
+            if (i === 0
+                || (gameRooms[gameRoomId].players[i].gameData.match.time < lowerMatchTime
+                    && gameRooms[gameRoomId].players[i].gameData.match.time >= 0))
                 lowerMatchTime = gameRooms[gameRoomId].players[i].gameData.match.time;
         }
 

--- a/src/codycolor-server/package-lock.json
+++ b/src/codycolor-server/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "codycolor-server",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/codycolor-server/package.json
+++ b/src/codycolor-server/package.json
@@ -1,6 +1,6 @@
 {
     "name": "codycolor-server",
-    "version": "3.3.2",
+    "version": "3.3.3",
     "description": "CodyColor server component",
     "main": "app.js",
     "scripts": {

--- a/src/codycolor-server/versions.js
+++ b/src/codycolor-server/versions.js
@@ -2,6 +2,6 @@
  * versions.js
  */
 (function () {
-    module.exports.requiredClient = '3.3.2';
-    module.exports.requiredWall = '3.3.2';
+    module.exports.requiredClient = '3.3.3';
+    module.exports.requiredWall = '3.3.3';
 }());


### PR DESCRIPTION
Various fixes following the analysis of test results:
* Changed old behavior (useful when the wall was in the Digit Showcase), in which match ends when a player did not confirm the next match, during aftermatch. This was the cause of the unexpected end of the match, during the test;
* Switched ranking in royale aftermatch (both in client and wall), modified aftermatch css for better visualization (in wall)
* In the server, added a guard against getLowerMatchTime returning values lower than zero (resulting in displaying "match time -1:-1" during the match). This is a temporary patch, as the causes of the problem is under investigation.
* Added callback onPlayerRemoved during matchmaking, in Wall. This caused the wall to display the wrong number of players, during matchmaking.
